### PR TITLE
fixes passing options to writable stream

### DIFF
--- a/lib/WritableStream.js
+++ b/lib/WritableStream.js
@@ -17,8 +17,8 @@ module.exports = WritableStream;
 
 util.inherits(WritableStream, Stream.Writable);
 
-function WritableStream () {
-  Stream.Writable.call(this);
+function WritableStream (options) {
+  Stream.Writable.call(this, options);
 }
 
 WritableStream.prototype.write = function(chunk, encoding, callback) {


### PR DESCRIPTION
It was not possible to pass any options to the allocation of the writable stream. See http://nodejs.org/api/stream.html#stream_class_stream_writable_1 for the possible options.

This is especially useful to allocate a writable stream with a non-default highWaterMarker e.g.:

``` js
var writeStream = new streams.WritableStream({
    highWaterMark: 32768
});
```
