### PR TITLE
Wrap `.end` so that it emits `finish`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Memory Streams JS
 _Memory Streams JS_ is a light-weight implementation of the `Stream.Readable` and `Stream.Writable` abstract classes from node.js. You can use the classes provided to store the result of reading and writing streams in memory. This can be useful when you need pipe your test output for later inspection or to stream files from the web into memory without have to use temporary files on disk.
 
+Forked from https://github.com/paulja/memory-streams-js to be modified
+so that `.end()` calls emit a `finish` event.
+
 ## Installation
 Install with:
 

--- a/lib/WritableStream.js
+++ b/lib/WritableStream.js
@@ -43,3 +43,11 @@ WritableStream.prototype.toBuffer = function() {
   
   return Buffer.concat(buffers);
 };
+
+WritableStream.prototype.end = function(chunk, encoding, callback) {
+  var ret = Stream.Writable.prototype.end.apply(this, arguments);
+  // In memory stream doesn't need to flush anything so emit `finish` right away
+  // base implementation in Stream.Writable doesn't emit finish
+  this.emit('finish');
+  return ret;
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memory-streams",
   "description": "Simple implmentation of Stream.Readable and Stream.Writable holding the data in memory.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Paul Jackson (http://jaaco.uk/)",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The nodeJS [documentation](https://nodejs.org/dist/latest-v8.x/docs/api/stream.html#stream_event_finish) for Writable Streams says that "The 'finish' event is emitted after the stream.end() method has been called, and all data has been flushed to the underlying system."

Since an in-memory stream doesn't have anywhere to flush anything, this would suggest that an in-memory implementation should emit the `finish` event as soon as the call to `.end` has written its chunk to the in-memory buffer.  The base implementation in Streams.Writable does not do this, however.  

This update adds to the in-memory implementation of WritableStream a wrapper for the `.end` function that emits the `finish` event after delegating any inputs received to the base implemenetation's `end` method.