### PR TITLE
Remove comment that was meant to be only in fork repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # Memory Streams JS
 _Memory Streams JS_ is a light-weight implementation of the `Stream.Readable` and `Stream.Writable` abstract classes from node.js. You can use the classes provided to store the result of reading and writing streams in memory. This can be useful when you need pipe your test output for later inspection or to stream files from the web into memory without have to use temporary files on disk.
 
-Forked from https://github.com/paulja/memory-streams-js to be modified
-so that `.end()` calls emit a `finish` event.
-
 ## Installation
 Install with:
 


### PR DESCRIPTION
@paulja - I noticed a comment I'd added to the readme that was intended for my fork slipped into the PR I'd submitted.  Here's a commit to clean that up.